### PR TITLE
remove host option and push all auth through login.procore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+* Use auth.procore.com for client credentials and access tokens
+
+  *Megan O'Neill*
+
 ## 0.8.6 (May 10, 2018)
 
 * Dalli Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-* Use auth.procore.com for client credentials and access tokens
+* Use login.procore.com for client credentials and access tokens
 
   *Megan O'Neill*
 

--- a/lib/procore/auth/access_token_credentials.rb
+++ b/lib/procore/auth/access_token_credentials.rb
@@ -3,11 +3,12 @@ require "oauth2"
 module Procore
   module Auth
     class AccessTokenCredentials
-      attr_reader :client_id, :client_secret, :host
-      def initialize(client_id:, client_secret:, host:)
+      attr_reader :client_id, :client_secret
+      AUTH_HOST = "https://auth.procore.com"
+
+      def initialize(client_id:, client_secret:)
         @client_id = client_id
         @client_secret = client_secret
-        @host = host
       end
 
       def refresh(token:, refresh:)
@@ -38,7 +39,7 @@ module Procore
         OAuth2::Client.new(
           client_id,
           client_secret,
-          site: "#{host}/oauth/token",
+          site: "#{AUTH_HOST}/oauth/token",
         )
       end
     end

--- a/lib/procore/auth/access_token_credentials.rb
+++ b/lib/procore/auth/access_token_credentials.rb
@@ -39,8 +39,12 @@ module Procore
         OAuth2::Client.new(
           client_id,
           client_secret,
-          site: "#{AUTH_HOST}/oauth/token",
+          site: "#{auth_host}/oauth/token",
         )
+      end
+
+      def auth_host
+        ::ENV.fetch("AUTH_HOST", nil) || AUTH_HOST
       end
     end
   end

--- a/lib/procore/auth/access_token_credentials.rb
+++ b/lib/procore/auth/access_token_credentials.rb
@@ -4,7 +4,6 @@ module Procore
   module Auth
     class AccessTokenCredentials
       attr_reader :client_id, :client_secret
-      AUTH_HOST = "https://auth.procore.com"
 
       def initialize(client_id:, client_secret:)
         @client_id = client_id
@@ -39,12 +38,8 @@ module Procore
         OAuth2::Client.new(
           client_id,
           client_secret,
-          site: "#{auth_host}/oauth/token",
+          site: "#{Procore.configuration.auth_host}/oauth/token",
         )
-      end
-
-      def auth_host
-        ::ENV.fetch("PROCORE_AUTH_HOST", nil) || AUTH_HOST
       end
     end
   end

--- a/lib/procore/auth/access_token_credentials.rb
+++ b/lib/procore/auth/access_token_credentials.rb
@@ -44,7 +44,7 @@ module Procore
       end
 
       def auth_host
-        ::ENV.fetch("AUTH_HOST", nil) || AUTH_HOST
+        ::ENV.fetch("PROCORE_AUTH_HOST", nil) || AUTH_HOST
       end
     end
   end

--- a/lib/procore/auth/client_credentials.rb
+++ b/lib/procore/auth/client_credentials.rb
@@ -49,7 +49,7 @@ module Procore
       end
 
       def auth_host
-        ::ENV.fetch("AUTH_HOST", nil) || AUTH_HOST
+        ::ENV.fetch("PROCORE_AUTH_HOST", nil) || AUTH_HOST
       end
     end
   end

--- a/lib/procore/auth/client_credentials.rb
+++ b/lib/procore/auth/client_credentials.rb
@@ -3,15 +3,16 @@ require "oauth2"
 module Procore
   module Auth
     class ClientCredentials
-      attr_reader :client_id, :client_secret, :host
-      def initialize(client_id:, client_secret:, host:)
+      attr_reader :client_id, :client_secret
+      AUTH_HOST = "https://auth.procore.com"
+
+      def initialize(client_id:, client_secret:)
         unless client_id && client_secret
           raise OAuthError.new("No client_id or client_secret provided.")
         end
 
         @client_id = client_id
         @client_secret = client_secret
-        @host = host
       end
 
       def refresh(*)
@@ -43,7 +44,7 @@ module Procore
         OAuth2::Client.new(
           client_id,
           client_secret,
-          site: "#{host}/oauth/token",
+          site: "#{AUTH_HOST}/oauth/token",
         )
       end
     end

--- a/lib/procore/auth/client_credentials.rb
+++ b/lib/procore/auth/client_credentials.rb
@@ -44,8 +44,12 @@ module Procore
         OAuth2::Client.new(
           client_id,
           client_secret,
-          site: "#{AUTH_HOST}/oauth/token",
+          site: "#{auth_host}/oauth/token",
         )
+      end
+
+      def auth_host
+        ::ENV.fetch("AUTH_HOST", nil) || AUTH_HOST
       end
     end
   end

--- a/lib/procore/auth/client_credentials.rb
+++ b/lib/procore/auth/client_credentials.rb
@@ -4,7 +4,6 @@ module Procore
   module Auth
     class ClientCredentials
       attr_reader :client_id, :client_secret
-      AUTH_HOST = "https://auth.procore.com"
 
       def initialize(client_id:, client_secret:)
         unless client_id && client_secret
@@ -44,12 +43,8 @@ module Procore
         OAuth2::Client.new(
           client_id,
           client_secret,
-          site: "#{auth_host}/oauth/token",
+          site: "#{Procore.configuration.auth_host}/oauth/token",
         )
-      end
-
-      def auth_host
-        ::ENV.fetch("PROCORE_AUTH_HOST", nil) || AUTH_HOST
       end
     end
   end

--- a/lib/procore/client.rb
+++ b/lib/procore/client.rb
@@ -24,7 +24,7 @@ module Procore
     # @param store [Auth::Store] A store to use for saving, updating and
     #   refreshing tokens
     # @param options [Hash] options to configure the client with
-    # @option options [String] :host Endpoint to use for the API. Defaults to 
+    # @option options [String] :host Endpoint to use for the API. Defaults to
     #   Configuration.host
     # @option options [String] :user_agent User Agent string to send along with
     #   the request. Defaults to Configuration.user_agent

--- a/lib/procore/client.rb
+++ b/lib/procore/client.rb
@@ -24,7 +24,7 @@ module Procore
     # @param store [Auth::Store] A store to use for saving, updating and
     #   refreshing tokens
     # @param options [Hash] options to configure the client with
-    # @option options [String] :host Endpoint to use for the API. Defaults to
+    # @option options [String] :host Endpoint to use for the API. Defaults to 
     #   Configuration.host
     # @option options [String] :user_agent User Agent string to send along with
     #   the request. Defaults to Configuration.user_agent
@@ -33,7 +33,6 @@ module Procore
       @credentials = Procore::Auth::AccessTokenCredentials.new(
         client_id: client_id,
         client_secret: client_secret,
-        host: @options[:host],
       )
       @store = store
     end

--- a/lib/procore/configuration.rb
+++ b/lib/procore/configuration.rb
@@ -32,6 +32,16 @@ module Procore
     # @return [String]
     attr_accessor :host
 
+    # @!attribute [rw] auth_host
+    # @note defaults to Defaults::AUTH_HOST
+    #
+    # Base authentication host name. Alter this depending on your environment - in a
+    # staging or test environment you may want to point this at a sandbox
+    # instead of production.
+    #
+    # @return [String]
+    attr_accessor :auth_host
+
     # @!attribute [rw] logger
     # @note defaults to nil
     #
@@ -79,6 +89,7 @@ module Procore
 
     def initialize
       @host = Procore::Defaults::API_ENDPOINT
+      @auth_host = Procore::Defaults::AUTH_HOST
       @logger = nil
       @max_retries = 1
       @timeout = 1.0

--- a/lib/procore/defaults.rb
+++ b/lib/procore/defaults.rb
@@ -6,6 +6,9 @@ module Procore
     # Default API endpoint
     API_ENDPOINT = "https://app.procore.com".freeze
 
+    # Default authentication endpoint
+    AUTH_HOST = "https://auth.procore.com".freeze
+
     # Default User Agent header string
     USER_AGENT = "Procore Ruby Gem #{Procore::VERSION}".freeze
 

--- a/lib/procore/defaults.rb
+++ b/lib/procore/defaults.rb
@@ -7,7 +7,7 @@ module Procore
     API_ENDPOINT = "https://app.procore.com".freeze
 
     # Default authentication endpoint
-    AUTH_HOST = "https://auth.procore.com".freeze
+    AUTH_HOST = "https://login.procore.com".freeze
 
     # Default User Agent header string
     USER_AGENT = "Procore Ruby Gem #{Procore::VERSION}".freeze

--- a/test/procore/auth/access_token_credentials_test.rb
+++ b/test/procore/auth/access_token_credentials_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class Procore::Auth::ClientCredentialsTest < Minitest::Test
   def test_refresh_token
-    stub_request(:post, "https://auth.procore.com/oauth/token")
+    stub_request(:post, "https://login.procore.com/oauth/token")
       .with(body: {
               "client_id" => "id",
               "client_secret" => "secret",
@@ -34,7 +34,7 @@ class Procore::Auth::ClientCredentialsTest < Minitest::Test
   end
 
   def test_oauth_client_error_with_html
-    stub_request(:post, "https://auth.procore.com/oauth/token")
+    stub_request(:post, "https://login.procore.com/oauth/token")
       .with(body: {
               "client_id" => "id",
               "client_secret" => "secret",
@@ -94,7 +94,7 @@ class Procore::Auth::ClientCredentialsTest < Minitest::Test
   end
 
   def test_connection_failed_error
-    stub_request(:post, "https://auth.procore.com/oauth/token")
+    stub_request(:post, "https://login.procore.com/oauth/token")
       .with(body: {
               "client_id" => "id",
               "client_secret" => "secret",

--- a/test/procore/auth/access_token_credentials_test.rb
+++ b/test/procore/auth/access_token_credentials_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class Procore::Auth::ClientCredentialsTest < Minitest::Test
   def test_refresh_token
-    stub_request(:post, "https://procore.example.com/oauth/token")
+    stub_request(:post, "https://auth.procore.com/oauth/token")
       .with(body: {
               "client_id" => "id",
               "client_secret" => "secret",
@@ -24,7 +24,6 @@ class Procore::Auth::ClientCredentialsTest < Minitest::Test
     credentials = Procore::Auth::AccessTokenCredentials.new(
       client_id: "id",
       client_secret: "secret",
-      host: "https://procore.example.com",
     )
 
     new_token = credentials.refresh(token: "token", refresh: "refresh")
@@ -35,7 +34,7 @@ class Procore::Auth::ClientCredentialsTest < Minitest::Test
   end
 
   def test_oauth_client_error_with_html
-    stub_request(:post, "https://procore.example.com/oauth/token")
+    stub_request(:post, "https://auth.procore.com/oauth/token")
       .with(body: {
               "client_id" => "id",
               "client_secret" => "secret",
@@ -51,7 +50,6 @@ class Procore::Auth::ClientCredentialsTest < Minitest::Test
     credentials = Procore::Auth::AccessTokenCredentials.new(
       client_id: "id",
       client_secret: "secret",
-      host: "https://procore.example.com",
     )
 
     error = assert_raises Procore::OAuthError do
@@ -82,7 +80,6 @@ class Procore::Auth::ClientCredentialsTest < Minitest::Test
     credentials = Procore::Auth::AccessTokenCredentials.new(
       client_id: "id",
       client_secret: "secret",
-      host: "https://procore.example.com",
     )
 
     error = assert_raises Procore::OAuthError do
@@ -97,7 +94,7 @@ class Procore::Auth::ClientCredentialsTest < Minitest::Test
   end
 
   def test_connection_failed_error
-    stub_request(:post, "https://procore.example.com/oauth/token")
+    stub_request(:post, "https://auth.procore.com/oauth/token")
       .with(body: {
               "client_id" => "id",
               "client_secret" => "secret",
@@ -108,34 +105,10 @@ class Procore::Auth::ClientCredentialsTest < Minitest::Test
     credentials = Procore::Auth::AccessTokenCredentials.new(
       client_id: "id",
       client_secret: "secret",
-      host: "https://procore.example.com",
     )
 
     assert_raises Procore::APIConnectionError do
       credentials.refresh(token: "token", refresh: "refresh")
     end
-  end
-
-  def test_bad_uri_error
-    stub_request(:post, "https://procore.example.com/oauth/token")
-      .with(
-        body: {
-          "client_id" => "id",
-          "client_secret" => "secret",
-          "grant_type" => "client_credentials",
-        },
-      )
-
-    credentials = Procore::Auth::AccessTokenCredentials.new(
-      client_id: "id",
-      client_secret: "secret",
-      host: "invalid-uri",
-    )
-
-    error = assert_raises Procore::OAuthError do
-      credentials.refresh(token: "token", refresh: "refresh")
-    end
-
-    assert_equal error.message, "Host is not a valid URI. Check your host option to make sure it is a properly formed url"
   end
 end

--- a/test/procore/auth/client_credentials_test.rb
+++ b/test/procore/auth/client_credentials_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class Procore::Auth::ClientCredentialsTest < Minitest::Test
   def test_get_token
-    stub_request(:post, "https://procore.example.com/oauth/token")
+    stub_request(:post, "https://auth.procore.com/oauth/token")
       .with(body: {
               "client_id" => "id",
               "client_secret" => "secret",
@@ -17,14 +17,13 @@ class Procore::Auth::ClientCredentialsTest < Minitest::Test
     token = Procore::Auth::ClientCredentials.new(
       client_id: "id",
       client_secret: "secret",
-      host: "https://procore.example.com",
     ).refresh
 
     assert_equal "token", token.access_token
   end
 
   def test_oauth_client_error_with_html
-    stub_request(:post, "https://procore.example.com/oauth/token")
+    stub_request(:post, "https://auth.procore.com/oauth/token")
       .with(body: {
               "client_id" => "id",
               "client_secret" => "secret",
@@ -39,7 +38,6 @@ class Procore::Auth::ClientCredentialsTest < Minitest::Test
     token = Procore::Auth::ClientCredentials.new(
       client_id: "id",
       client_secret: "secret",
-      host: "https://procore.example.com",
     )
 
     error = assert_raises Procore::OAuthError do
@@ -54,7 +52,7 @@ class Procore::Auth::ClientCredentialsTest < Minitest::Test
   end
 
   def test_oauth_client_error_with_json
-    stub_request(:post, "https://procore.example.com/oauth/token")
+    stub_request(:post, "https://auth.procore.com/oauth/token")
       .with(body: {
               "client_id" => "id",
               "client_secret" => "secret",
@@ -69,7 +67,6 @@ class Procore::Auth::ClientCredentialsTest < Minitest::Test
     token = Procore::Auth::ClientCredentials.new(
       client_id: "id",
       client_secret: "secret",
-      host: "https://procore.example.com",
     )
 
     error = assert_raises Procore::OAuthError do
@@ -84,7 +81,7 @@ class Procore::Auth::ClientCredentialsTest < Minitest::Test
   end
 
   def test_connection_failed_error
-    stub_request(:post, "https://procore.example.com/oauth/token")
+    stub_request(:post, "https://auth.procore.com/oauth/token")
       .with(
         body: {
           "client_id" => "id",
@@ -96,7 +93,6 @@ class Procore::Auth::ClientCredentialsTest < Minitest::Test
     token = Procore::Auth::ClientCredentials.new(
       client_id: "id",
       client_secret: "secret",
-      host: "https://procore.example.com",
     )
 
     assert_raises Procore::APIConnectionError do
@@ -104,31 +100,8 @@ class Procore::Auth::ClientCredentialsTest < Minitest::Test
     end
   end
 
-  def test_bad_uri_error
-    stub_request(:post, "https://procore.example.com/oauth/token")
-      .with(
-        body: {
-          "client_id" => "id",
-          "client_secret" => "secret",
-          "grant_type" => "client_credentials",
-        },
-      )
-
-    token = Procore::Auth::ClientCredentials.new(
-      client_id: "id",
-      client_secret: "secret",
-      host: "invalid-uri",
-    )
-
-    error = assert_raises Procore::OAuthError do
-      token.refresh
-    end
-
-    assert_equal error.message, "Host is not a valid URI. Check your host option to make sure it is a properly formed url"
-  end
-
   def test_procore_oauth_error
-    stub_request(:post, "https://procore.example.com/oauth/token")
+    stub_request(:post, "https://auth.procore.com/oauth/token")
       .with(
         body: {
           "client_id" => "id",
@@ -140,7 +113,6 @@ class Procore::Auth::ClientCredentialsTest < Minitest::Test
     token = Procore::Auth::ClientCredentials.new(
       client_id: "id",
       client_secret: "secret",
-      host: "https://procore.example.com",
     )
 
     assert_raises Procore::OAuthError do

--- a/test/procore/auth/client_credentials_test.rb
+++ b/test/procore/auth/client_credentials_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class Procore::Auth::ClientCredentialsTest < Minitest::Test
   def test_get_token
-    stub_request(:post, "https://auth.procore.com/oauth/token")
+    stub_request(:post, "https://login.procore.com/oauth/token")
       .with(body: {
               "client_id" => "id",
               "client_secret" => "secret",
@@ -23,7 +23,7 @@ class Procore::Auth::ClientCredentialsTest < Minitest::Test
   end
 
   def test_oauth_client_error_with_html
-    stub_request(:post, "https://auth.procore.com/oauth/token")
+    stub_request(:post, "https://login.procore.com/oauth/token")
       .with(body: {
               "client_id" => "id",
               "client_secret" => "secret",
@@ -52,7 +52,7 @@ class Procore::Auth::ClientCredentialsTest < Minitest::Test
   end
 
   def test_oauth_client_error_with_json
-    stub_request(:post, "https://auth.procore.com/oauth/token")
+    stub_request(:post, "https://login.procore.com/oauth/token")
       .with(body: {
               "client_id" => "id",
               "client_secret" => "secret",
@@ -81,7 +81,7 @@ class Procore::Auth::ClientCredentialsTest < Minitest::Test
   end
 
   def test_connection_failed_error
-    stub_request(:post, "https://auth.procore.com/oauth/token")
+    stub_request(:post, "https://login.procore.com/oauth/token")
       .with(
         body: {
           "client_id" => "id",
@@ -101,7 +101,7 @@ class Procore::Auth::ClientCredentialsTest < Minitest::Test
   end
 
   def test_procore_oauth_error
-    stub_request(:post, "https://auth.procore.com/oauth/token")
+    stub_request(:post, "https://login.procore.com/oauth/token")
       .with(
         body: {
           "client_id" => "id",

--- a/test/support/auth_stubs.rb
+++ b/test/support/auth_stubs.rb
@@ -1,6 +1,6 @@
 module AuthStubs
-  def stub_client_credentials_token(host: "https://procore.example.com")
-    stub_request(:post, "#{host}/oauth/token")
+  def stub_client_credentials_token
+    stub_request(:post, "https://auth.procore.com/oauth/token")
       .to_return(
         status: 200,
         body: { access_token: "token" }.to_json,
@@ -9,7 +9,7 @@ module AuthStubs
   end
 
   def stub_refresh_token
-    stub_request(:post, "https://procore.example.com/oauth/token")
+    stub_request(:post, "https://auth.procore.com/oauth/token")
       .to_return(
         status: 200,
         body: {

--- a/test/support/auth_stubs.rb
+++ b/test/support/auth_stubs.rb
@@ -1,6 +1,6 @@
 module AuthStubs
   def stub_client_credentials_token
-    stub_request(:post, "https://auth.procore.com/oauth/token")
+    stub_request(:post, "https://login.procore.com/oauth/token")
       .to_return(
         status: 200,
         body: { access_token: "token" }.to_json,
@@ -9,7 +9,7 @@ module AuthStubs
   end
 
   def stub_refresh_token
-    stub_request(:post, "https://auth.procore.com/oauth/token")
+    stub_request(:post, "https://login.procore.com/oauth/token")
       .to_return(
         status: 200,
         body: {


### PR DESCRIPTION
### Changes
- All authentication via the sdk will go directly to `login.procore.com` instead of to `app.procore.com`
- Optionally reads from ENVAR for local dev'ing
- This will require updates to the internal sdk since we're no longer passing `host` around and using that to determine where we're auth'ing

### Testing
- [ ] How do we want to test this out?