### PR TITLE
chore: drop ruby 2.7 support

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,10 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        ruby: ['3.0', '3.1', '3.2']
-        include:
-          - os: ubuntu-20.04
-            ruby: '2.7'
+        ruby: ['3.0', '3.1', '3.2', '3.3']
     runs-on: ${{ matrix.os }}
     services:
       redis:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,11 +6,11 @@ Ruby versions that are currently being supported with security updates.
 
 | Version | Supported          |
 | ------- | ------------------ |
-| <=2.6   | :x:                |
-| 2.7     | :white_check_mark: |
+| <=2.7   | :x:                |
 | 3.0     | :white_check_mark: |
 | 3.1     | :white_check_mark: |
 | 3.2     | :white_check_mark: |
+| 3.3     | :white_check_mark: |
 
 ## Reporting a Vulnerability
 

--- a/procore.gemspec
+++ b/procore.gemspec
@@ -5,15 +5,16 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "procore/version"
 
 Gem::Specification.new do |spec|
-  spec.name          = "procore"
-  spec.version       = Procore::VERSION
-  spec.authors       = ["Procore Technologies, Inc."]
-  spec.email         = ["opensource@procore.comm"]
+  spec.name                  = "procore"
+  spec.version               = Procore::VERSION
+  spec.authors               = ["Procore Technologies, Inc."]
+  spec.email                 = ["opensource@procore.comm"]
 
-  spec.summary       = "Procore Ruby Gem"
-  spec.description   = "Procore Ruby Gem"
-  spec.homepage      = "https://github.com/procore-oss/ruby-sdk"
-  spec.license       = "MIT"
+  spec.summary               = "Procore Ruby Gem"
+  spec.description           = "Procore Ruby Gem"
+  spec.homepage              = "https://github.com/procore-oss/ruby-sdk"
+  spec.license               = "MIT"
+  spec.required_ruby_version = Gem::Requirement.new('>= 3.0')
 
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})


### PR DESCRIPTION
- [x] update all files to meet new ruby version minimum (3.0)

Checklist:

* [x] I have updated the necessary documentation
* [x] I have signed off all my commits as required by [DCO](https://github.com/procore-oss/ruby-sdk/blob/main/CONTRIBUTING.md)
* [x] My build is green

<!--
Note on DCO:

If the DCO check fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Note on Versioning:

Maintainers will bump the version and do a release when they are ready to release (possibly multiple merged PRs). Please do not bump the version in your PRs.
-->
