### PR TITLE
chore: group dependabot updates when minor/patch

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -9,6 +9,14 @@ updates:
       - "dependabot"
       - "dependencies"
       - "github-actions"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      dependencies:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
   - package-ecosystem: "bundler"
     directory: /
     schedule:
@@ -18,3 +26,11 @@ updates:
       - "dependabot"
       - "dependencies"
       - "bundler"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      dependencies:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/auto-assign-author.yaml
+++ b/.github/workflows/auto-assign-author.yaml
@@ -1,11 +1,13 @@
 name: 'Auto Author Assign'
-
 on:
   pull_request_target:
     types: [opened, reopened]
-
+permissions:
+  contents: read
 jobs:
   assign-author:
+    permissions:
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: toshimaru/auto-author-assign@v2.1.0

--- a/procore.gemspec
+++ b/procore.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rubocop-performance"
   spec.add_development_dependency "rubocop-rails"
   spec.add_development_dependency "simplecov"
-  spec.add_development_dependency "sqlite3"
+  spec.add_development_dependency "sqlite3", "~>1.4"
   spec.add_development_dependency "webmock"
 
   spec.add_dependency "activesupport", "> 2.4"


### PR DESCRIPTION
- [x] change dependabot config to group dependencies
  - leave major dependency updates to their own PR so they stand out and are tested correctly
  - prefix the PRs with `chore(deps)` to adhere to conventional commits
- [x] change GitHub Actions to use SHAs instead of tags
  - Why?
    - To prevent supply chain attack. Tags can move. They are mutable. SHAs are not.
  - used [frizbee](https://github.com/stacklok/frizbee)
    - ran `frizbee ghactions -d .github/workflows` locally
    - also fixes formatting

Checklist:

* [x] I have updated the necessary documentation
* [x] I have signed off all my commits as required by [DCO](https://github.com/procore-oss/ruby-sdk/blob/main/CONTRIBUTING.md)
* [ ] My build is green

<!--
Note on DCO:

If the DCO check fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Note on Versioning:

Maintainers will bump the version and do a release when they are ready to release (possibly multiple merged PRs). Please do not bump the version in your PRs.
-->
